### PR TITLE
Only override username password if not empty

### DIFF
--- a/plugins/pinotjdbc/connectionProperties.js
+++ b/plugins/pinotjdbc/connectionProperties.js
@@ -26,8 +26,16 @@
     props[CONTROLLER_TLS_KEY] = attr["v-controller-tls"];
 
     if (attr[connectionHelper.attributeAuthentication] === "auth-user-pass") {
-        props[USER_KEY] = attr[connectionHelper.attributeUsername];
-        props[PASSWORD_KEY] = attr[connectionHelper.attributePassword];
+        const username = attr[connectionHelper.attributeUsername];
+        const password = attr[connectionHelper.attributePassword];
+        // On Tableau Server, secure fields may not be exposed to JS; avoid
+        // overwriting server-supplied credentials with empty values.
+        if (username) {
+            props[USER_KEY] = username;
+        }
+        if (password) {
+            props[PASSWORD_KEY] = password;
+        }
     }
 
     // Parse additional properties passed through additional properties attribute

--- a/plugins/pinotjdbc/connectionProperties.js
+++ b/plugins/pinotjdbc/connectionProperties.js
@@ -30,10 +30,10 @@
         const password = attr[connectionHelper.attributePassword];
         // On Tableau Server, secure fields may not be exposed to JS; avoid
         // overwriting server-supplied credentials with empty values.
-        if (username) {
+        if (username !== undefined && username !== '') {
             props[USER_KEY] = username;
         }
-        if (password) {
+        if (password !== undefined && password !== '') {
             props[PASSWORD_KEY] = password;
         }
     }


### PR DESCRIPTION
* On Tableau Server, secure fields (like password) aren’t passed to the connectionProperties.js.
* Our connector is still writing an empty password into the JDBC props, which ends up overwriting Server-embedded creds.
* Pinot then sees blank password and rejects connection.

This PR is needed to fix this issue
