### PR TITLE
Update Taco Release workflow for Github actions v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,6 +121,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./target/ai.startree.pinot-startree-tableau-connector-${{ needs.build_and_sign.outputs.VERSION }}.taco
+          asset_path: ./ai.startree.pinot-startree-tableau-connector-${{ needs.build_and_sign.outputs.VERSION }}.taco
           asset_name: ai.startree.pinot-startree-tableau-connector-${{ needs.build_and_sign.outputs.VERSION }}.taco
           asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Build and Sign Tableau Connector
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:
@@ -35,12 +38,11 @@ jobs:
       - name: Fetch latest version
         id: fetch_latest_version
         run: |
-          # Replace this URL with your Maven repository's maven-metadata.xml URL
           MAVEN_METADATA_URL='https://repo.maven.apache.org/maven2/org/apache/pinot/pinot-jdbc-client/maven-metadata.xml'
           LATEST_VERSION=$(curl -s "$MAVEN_METADATA_URL" | grep -oPm1 "(?<=<latest>)[^<]+")
           echo "Latest version: $LATEST_VERSION"
           echo "VERSION=$LATEST_VERSION" >> $GITHUB_ENV
-          echo "::set-output name=VERSION::$LATEST_VERSION"
+          echo "VERSION=$LATEST_VERSION" >> $GITHUB_OUTPUT
 
       - name: Check if release exists
         id: check_release
@@ -85,10 +87,11 @@ jobs:
         run: mvn clean package
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tableau-connector
           path: target/*.taco
+          if-no-files-found: error
 
   release:
     needs: build_and_sign
@@ -96,9 +99,10 @@ jobs:
     if: ${{ needs.build_and_sign.outputs.RELEASE_EXISTS == 'false' }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tableau-connector
+          path: .
 
       - name: Create release
         id: create_release
@@ -117,6 +121,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./ai.startree.pinot-startree-tableau-connector-${{ needs.build_and_sign.outputs.VERSION }}.taco
+          asset_path: ./target/ai.startree.pinot-startree-tableau-connector-${{ needs.build_and_sign.outputs.VERSION }}.taco
           asset_name: ai.startree.pinot-startree-tableau-connector-${{ needs.build_and_sign.outputs.VERSION }}.taco
           asset_content_type: application/octet-stream


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and releasing the Tableau Connector. The main improvements include enhanced permissions, updated artifact management, and more reliable output handling.

**Workflow configuration updates:**

* Added `permissions` section with `contents: write` to allow the workflow to create releases and upload artifacts.

**Artifact and output handling enhancements:**

* Updated the artifact upload and download steps to use `actions/upload-artifact@v4` and `actions/download-artifact@v4`, ensuring compatibility with the latest features and improved stability. Also added `if-no-files-found: error` to fail the build if the artifact is missing.
* Changed output handling in the "Fetch latest version" step to use `$GITHUB_OUTPUT` instead of the deprecated `::set-output` command.